### PR TITLE
Provide ability to bypass HTTPS certificate verification

### DIFF
--- a/src/servicenow/Connection.py
+++ b/src/servicenow/Connection.py
@@ -6,7 +6,7 @@ from servicenow import Utils
 
 class Auth(object):
 
-    def __init__(self, username, password, instance, timeout=60, debug=False, api='JSON', proxies={}):
+    def __init__(self, username, password, instance, timeout=60, debug=False, api='JSON', proxies={}, verify=True):
         self.username = username
         self.password = password
         if 'https://' in instance:
@@ -18,6 +18,7 @@ class Auth(object):
         self.session.auth = (self.username, self.password)
         self.api = api
         self.proxies = proxies
+        self.verify = verify
         if api.startswith('JSON'):
             self.session.headers.update({'Accept': 'application/json'})
 
@@ -29,7 +30,7 @@ class Auth(object):
             'sysparm_action':   'getKeys',
             'sysparm_query': query
         })
-        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies)
+        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _list_by_query(self, table, query, **kwargs):
         params = kwargs.get('params', {})
@@ -38,7 +39,7 @@ class Auth(object):
             'sysparm_action':   'getKeys',
             'sysparm_query':    query
         })
-        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies)
+        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _get(self, table, meta={}, **kwargs):
         query = Utils.format_query(meta, kwargs.get('metaon', {}))
@@ -48,7 +49,7 @@ class Auth(object):
             'sysparm_action':   'getRecords',
             'sysparm_query': query
         })
-        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies)
+        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _get_by_query(self, table, query, **kwargs):
         params = kwargs.get('params', {})
@@ -57,7 +58,7 @@ class Auth(object):
             'sysparm_action':   'getRecords',
             'sysparm_query': query
         })
-        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies)
+        return self.session.get('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _post(self, table, data, **kwargs):
         params = kwargs.get('params', {})
@@ -65,7 +66,7 @@ class Auth(object):
             self.api:             '',
             'sysparm_action':   'insert'
         })
-        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies)
+        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _post_multiple(self, table, data, **kwargs):
         params = kwargs.get('params', {})
@@ -73,7 +74,7 @@ class Auth(object):
             self.api:             '',
             'sysparm_action':   'insertMultiple'
         })
-        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies)
+        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _update(self, table, where, data, **kwargs):
         query = Utils.format_query(where, {})
@@ -83,7 +84,7 @@ class Auth(object):
             'sysparm_action':   'update',
             'sysparm_query':    query
         })
-        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies)
+        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _update_by_query(self, table, query, data, **kwargs):
         params = kwargs.get('params', {})
@@ -92,7 +93,7 @@ class Auth(object):
             'sysparm_action':   'update',
             'sysparm_query':    query
         })
-        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies)
+        return self.session.post('%s/%s' % (self.instance, table), params=params, data=json.dumps(data), timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _delete(self, table, id, **kwargs):
         params = kwargs.get('params', {})
@@ -101,7 +102,7 @@ class Auth(object):
             'sysparm_action':   'deleteRecord',
             'sysparm_sys_id':    id
         })
-        return self.session.post('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies)
+        return self.session.post('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _delete_multiple(self, table, query, **kwargs):
         params = kwargs.get('params', {})
@@ -110,7 +111,7 @@ class Auth(object):
             'sysparm_action':   'deleteMultiple',
             'sysparm_query':    query
         })
-        return self.session.post('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies)
+        return self.session.post('%s/%s' % (self.instance, table), params=params, timeout=self.timeout, proxies=self.proxies, verify=self.verify)
 
     def _format(self, response):
         return json.loads(response.text)


### PR DESCRIPTION
Sometimes, for example on a test instance, you may use a self-signed certificate.

This will allow you to interact with the service without requiring the certificate to be trusted.